### PR TITLE
- Upgrade for Debian Stretch:

### DIFF
--- a/jailspaces/js.conf
+++ b/jailspaces/js.conf
@@ -2,7 +2,8 @@ _USER_LIST_CMD="members webspaceuser | tr \" \" \"\n\""
 _NGINX_CONF="/etc/nginx/conf.d/@USERNAME@.conf"
 _NGINX_USER="nginx"
 _NGINX_USERGROUP="nginx"
-_PHP_FPM_CONF="/etc/php5/fpm/pool.d/@USERNAME@.conf"
+_PHP_FPM_SERVICE="php7.0-fpm"
+_PHP_FPM_CONF="/etc/php/7.0/fpm/pool.d/@USERNAME@.conf"
 _PHP_FPM_CHROOT="/home/www/@USERNAME@/chroot"
 _PHP_FPM_CHROOT_DIRS="\
 	/,0010,root:@USERNAME@,d \
@@ -13,8 +14,8 @@ _PHP_FPM_CHROOT_DIRS="\
 	/tmp/session,0030,root:@USERNAME@,d \
 	/tmp/wsdl,0030,root:@USERNAME@,d \
 	/tmp/upload,0030,root:@USERNAME@,d \
-	/log/php5-fpm-pool.log,0600,root:@USERNAME@,f \
-	/log/php5-fpm-slow.log,0600,root:@USERNAME@,f"
+	/log/php-fpm-pool.log,0600,root:@USERNAME@,f \
+	/log/php-fpm-slow.log,0600,root:@USERNAME@,f"
 
 _PHP_FPM_CHROOT_BIND="\
 	/usr/share/zoneinfo \
@@ -33,7 +34,7 @@ _NGINX_CONF_TEMPLATE="/etc/jailspaces/template/nginx.conf.template"
 _NGINX_CONF_TEMPLATE_OWNER="$_NGINX_USER:$_NGINX_USERGROUP"
 _NGINX_CONF_TEMPLATE_MODE="0644"
 
-_PHP_FPM_CONF_TEMPLATE="/etc/jailspaces/template/php5-fpm.conf.template"
+_PHP_FPM_CONF_TEMPLATE="/etc/jailspaces/template/php-fpm.conf.template"
 _PHP_FPM_CONF_TEMPLATE_OWNER="root:root"
 _PHP_FPM_CONF_TEMPLATE_MODE="0660"
 
@@ -48,8 +49,6 @@ _LETS_ENCRYPT_CHALLENGE_DIR="/home/certmanager/acme-challenge"
 _LETS_ENCRYPT_ACME_TINY="/home/certmanager/acme_tiny.py"
 _LETS_ENCRYPT_EXPIRY=$((60*60*24*2))
 _LETS_ENCRYPT_KEYLENGTH=4096 # RSA keylength
-_LETS_ENCRYPT_INTERMEDIATE="/home/certmanager/intermediate.pem"
-_LETS_ENCRYPT_INTERMEDIATE_URL="https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem"
 
 _LETS_ENCRYPT_CSR_DIR="/home/certmanager/csr"
 _LETS_ENCRYPT_CSR_MODE="0640"
@@ -71,4 +70,4 @@ _POST_CREATE_CMD="install_template \"/etc/jailspaces/template/index.php.template
 
 _NGINX_ADD_GROUP_CMD="usermod -a -G \"@USERNAME@\" \"$_NGINX_USER\""
 _RELOAD_NGINX_CMD="systemctl reload-or-restart nginx" # This command must be in sudoers file for _LETS_ENCRYPT_USER with NOPASSWD:
-_RELOAD_PHP_FPM_CMD="systemctl reload-or-restart php5-fpm"
+_RELOAD_PHP_FPM_CMD="systemctl reload-or-restart php7.0-fpm"

--- a/jailspaces/template/nginx.conf.template
+++ b/jailspaces/template/nginx.conf.template
@@ -24,7 +24,7 @@ server {
         location ~ \.php$ {
 		try_files  $uri =404;
                 include /etc/nginx/fastcgi_params;
-                fastcgi_pass unix:/var/run/php5-fpm-@USERNAME@.sock;
+                fastcgi_pass unix:/var/run/php-fpm-@USERNAME@.sock;
                 fastcgi_param SCRIPT_FILENAME /data-@USERNAME@$fastcgi_script_name;
         }
 

--- a/jailspaces/template/php-fpm.conf.template
+++ b/jailspaces/template/php-fpm.conf.template
@@ -2,7 +2,7 @@
 user = $pool
 group = $pool
 
-listen = /var/run/php5-fpm-$pool.sock
+listen = /var/run/php-fpm-$pool.sock
 listen.owner = nginx
 listen.group = nginx
 
@@ -15,18 +15,18 @@ pm.max_children = 5
 ;pm.min_spare_servers = 1
 ;pm.max_spare_servers = 3
 
-pm.status_path = /php5-fpm-status
-ping.path = /php5-fpm-ping
+pm.status_path = /php-fpm-status
+ping.path = /php-fpm-ping
 
-access.log = /home/www/$pool/chroot/log/php5-fpm-pool.log
-slowlog = /home/www/$pool/chroot/log/php5-fpm-slow.log
+access.log = /home/www/$pool/chroot/log/php-fpm-pool.log
+slowlog = /home/www/$pool/chroot/log/php-fpm-slow.log
 request_slowlog_timeout = 15s
 
 chroot = /home/www/$pool/chroot/
 
 chdir = /
 
-# Flags & limits
+;Flags & limits
 php_flag[display_errors] = off
 php_admin_flag[log_errors] = on
 php_admin_flag[expose_php] = off
@@ -35,7 +35,7 @@ php_admin_value[post_max_size] = 24M
 php_admin_value[upload_max_filesize] = 20M
 php_admin_value[cgi.fix_pathinfo] = 0
 
-# Session
+;Session
 php_admin_value[session.entropy_length] = 1024
 php_admin_value[session.cookie_httponly] = on
 php_admin_value[session.hash_function] = sha512
@@ -44,7 +44,7 @@ php_admin_value[session.gc_probability] = 1
 php_admin_value[session.gc_divisor] = 1000
 php_admin_value[session.gc_maxlifetime] = 1440
 
-# Pathes
+;Pathes
 php_admin_value[include_path] = .
 php_admin_value[open_basedir] = /data-$pool/:/tmp/misc/:/tmp/upload/:/dev/urandom
 php_admin_value[sys_temp-dir] = /tmp/misc


### PR DESCRIPTION
    - Use php7.0-fpm instead of php5-fpm
    - Edit php-fpm pool template to get compatible with php7.0
    - Edit nginx host template to use new php7.0 unix socket
    - Removed generation of systemd unit files for remount bind mounts with readonly option since ro option can now be used directly with mount command / unit
- Removed Lets Encrypt intermediate certificate handling since it is now automaticaly requested by acme_tiny
- Added _PHP_FPM_SERVICE variable to js.conf to simplify future upgrades